### PR TITLE
fixup! fixes #589

### DIFF
--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -386,7 +386,7 @@ class ggplot(object):
             quantiles_actual = quantiles = data[colname].quantile([0., .2, 0.4, 0.5, 0.6, 0.75, 1.0])
             # TODO: NOT SURE IF THIS ACTUALLY WORKS WELL. could get a divide by 0 error
             quantiles = (quantiles - quantiles.min()) / (quantiles.max()) # will be bug if max is 0
-            mappers['color'] = { "name": colname, "lookup": {} }
+            mappers['color'] = { "name": colname, "lookup": OrderedDict() }
             colors = cmap(quantiles)
             for i, q in enumerate(quantiles_actual):
                 mappers['color']['lookup'][q] = colors[i]
@@ -399,7 +399,7 @@ class ggplot(object):
             quantiles_scaled = (quantiles - quantiles.min()) / (quantiles.max()) # will be bug if max is 0
             mappers['alpha'] = {
                 "name": colname,
-                "lookup": dict(zip(quantiles.values, quantiles_scaled.values))
+                "lookup": OrderedDict(zip(quantiles.values, quantiles_scaled.values))
             }
             data[colname] = (data[colname] - data[colname].min()) / data[colname].max()
             discrete_aes.append(('alpha', colname))
@@ -411,7 +411,7 @@ class ggplot(object):
             quantiles_scaled = (quantiles - quantiles.min()) / (quantiles.max()) # will be bug if max is 0
             mappers['size'] = {
                 "name": colname,
-                "lookup":  dict(zip(quantiles.values, 100 * quantiles_scaled.values))
+                "lookup":  OrderedDict(zip(quantiles.values, 100 * quantiles_scaled.values))
             }
             data[colname] = 100 * (data[colname] - data[colname].min()) / data[colname].max()
             discrete_aes.append(('size', colname))


### PR DESCRIPTION
All lookups need to be `OrderedDict`'s, otherwise the ordering is lost for non-categorical scales due to the removed `sorted()` call in `legend.py`.

Feel free to squash this fixup with your original commit.